### PR TITLE
deployrsyncタスク(rsyncを使ったデプロイ)を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2018-10-12
+
+### Added
+
+- [x] ベストプラクティスに基づいたディレクトリ構成やファイルを追加
+- [x] productionビルドの用意
+- [x] greenkeeper追加
+- [x] デプロイタスクを追加
+- [x] Bitbucket Pipelineによる自動デプロイの仕組みを追加
+- [x] https://github.com/fourdigit/scss-utilities 追加
+
+### Modified
+
+- [x] 利用頻度が高いタスクをデフォルトでonに
+- [x] config.jsを削除して、taskのコンフィグを直接変更するように。(packageに隠蔽できていない状態でconfigが2箇所にあると、混乱をまねいてしまうケースが非常に多かったため)
+- [x] Stylus, Stylint, jsdoc, jsdoc2md, サポートの停止(jsdocはあっても良いかもしれない)
+
+### Fixed
+
+- [x] EJS、`/src`基準のパスで書けるように修正
+- [x] EJS、`.ejs`で動くように修正(`.html`に設定されていたので)
+- [x] EJS、_が頭についているファイルをbuildに出さないように
+- [x] Styleguideで、修正したaigisを使うように修正(`EJS`のルート指定のため)
+- [x] Sass、CSS importができるように `node-sass-package-importer` 追加
+- [x] Sass、autoprefixer指定が壊れている(無意味に2回呼び出されている？)ので修正
+- [x] Sass、_が頭についているファイルをbuildに出さないように
+- [x] Sass、postCSSの設定ミス修正(spritesheetでうまくいかない場合があるので無効化)
+- [x] Eslint task追加(jQueryのdoller-sign関係も修正)
+- [x] webpack, js修正時にreload
+- [x] webpack, js, jsx拡張子に対応(非標準のes6拡張子を避ける)
+- [x] webpack, developmentビルドとproductionビルドを分ける
+
+## [2.0.0] - 2018-07-04
+
+V2. Gulp 4 version.
+
+
+## [1.0.0] - 2016-10-17
+
+Initial commit

--- a/README.md
+++ b/README.md
@@ -28,10 +28,12 @@ Gulp based project skeleton with modular tasks.
 ### js settings
 
 - see `/webpack.config.js`, `/webpack.config.prod.js` & `/gulpset/tasks/scripts/index.js`
-- Want to use es5? Do following steps.
-  - `/.eslintrc`: modify `@fourdigit/eslint-config-fourdigit/esnext` => `@fourdigit/eslint-config-fourdigit/base`
-  - modify `copy` task
-  - remove `scripts` task from `gulpfile.js`
+
+#### When you use ES5
+
+1. `/.eslintrc`: modify `@fourdigit/eslint-config-fourdigit/esnext` => `@fourdigit/eslint-config-fourdigit/base`
+2. modify `copy` task (add `js` ext)
+3. remove `scripts` task from `gulpfile.js`
 
 ### scss settings
 
@@ -45,12 +47,17 @@ Gulp based project skeleton with modular tasks.
 
 ### deployrsync settings
 
-- see `/gulpset/tasks/deployrsync/index.js`
-- set target user:hostname to `gulpset.confs.deployrsync.options.hostname`
-- `gulp deployrsync` command will deploy files in build destination folder
-- Want to deploy via bitbucket-pipelines?
-  - enter repository settings on bitbuket web
-    - Pipelines settings > Enable Pipelines
-    - Environment variables > make and set `PRIVATE_KEY` (<-must encrypt!) and `TARGET_HOST`
-  - built files by newly pushed `develop` branch will be deployed to `TARGET_HOST`
-  - if you want to use other branches, rewrite `branches` section on `bitbucket-pipelines.yml`
+1. Open `/gulpset/tasks/deployrsync/index.js`
+2. Set target user:hostname to `gulpset.confs.deployrsync.options.hostname`
+3. Add private key of target server. e.g. `ssh-add ~/.ssh/xxxxxxxx_rsa`
+4. Run `gulp deployrsync`
+
+#### Deploy via bitbucket-pipelines
+
+1. Create private key for target server.
+2. Encode it into base 64. e.g `$ base64 gulpset_rsa| pbcopy`
+3. On bitbucket web screen, enter repository settings
+4. Go Pipelines settings > Enable Pipelines
+5. Environment variables > make and set `PRIVATE_KEY` (make sure the to enable checkbox of "encrypt") and `TARGET_HOST`
+6. Built files by newly pushed `develop` branch will be deployed to `TARGET_HOST`
+7. if you want to use other branches, rewrite `branches` section on `bitbucket-pipelines.yml`

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ Gulp based project skeleton with modular tasks.
 
 - see `/gulpset/tasks/ejs/index.js`
 - some utility functions are included here `/src/_utils.ejs`
+
+### deployrsync settings
+
+- see `/gulpset/tasks/deployrsync/index.js`
+- set target user:hostname to `gulpset.confs.deployrsync.options.hostname`
+- `gulp deployrsync` command will deploy files in build destination folder
+- Want to deploy via bitbucket-pipelines?
+  - enter repository settings on bitbuket web
+    - Pipelines settings > Enable Pipelines
+    - Environment variables > make and set `PRIVATE_KEY` (<-must encrypt!) and `TARGET_HOST`
+  - built files by newly pushed `develop` branch will be deployed to `TARGET_HOST`
+  - if you want to use other branches, rewrite `branches` section on `bitbucket-pipelines.yml`

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -1,0 +1,31 @@
+# This is a sample build configuration for Javascript.
+# Check our guides at https://confluence.atlassian.com/x/VYk8Lw for more examples.
+# Only use spaces to indent your .yml configuration.
+# -----
+# You can specify a custom docker image from Docker Hub as your build environment.
+# 高速化のため、node+rsyncのカスタムイメージを使用 https://hub.docker.com/r/fourdigit/node-rsync-tagged/
+image: fourdigit/node-rsync-tagged:8.10.0
+clone:
+    depth: 1 # shallow clone http://qiita.com/sonots/items/ce08c30d161ea0b4d5fd
+
+pipelines:
+    branches:
+        'develop':
+            - step:
+                script:
+                    # # テストアップサーバー鍵の登録
+                    # - mkdir ~/.ssh
+                    - echo $PRIVATE_KEY > ~/.ssh/deploy-target_rsa.tmp # Bitbucket上の設定 > PIPELINES > Environment variablesから入れる。登録時Secured推奨。改行を効かせるため、環境変数に入れる前に$base64 gulpset_rsa| pbcopy
+                    - base64 -d ~/.ssh/deploy-target_rsa.tmp > ~/.ssh/deploy-target_rsa
+                    - chmod 400 ~/.ssh/deploy-target_rsa
+                    - eval `ssh-agent` # ssh-agentコマンドを直接たたくのだとうまくいかないので、evalで。参考：　http://qiita.com/sshojiro/items/60982f06c1a0ba88c160
+                    - ssh-add ~/.ssh/deploy-target_rsa
+                    - ssh-keyscan -H $TARGET_HOST >> ~/.ssh/known_hosts
+                    # - echo "$TARGET_HOST ssh-rsa $FINGERPRINT" >> ~/.ssh/known_hosts
+
+                    # yarn, gulpインストールからデプロイまで
+                    - npm i yarn -g
+                    - npm install -g "gulpjs/gulp#4.0"
+                    - yarn
+                    - gulp production
+                    - gulp deployrsync

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,7 @@ gulpset.gulp.task(
   )
 );
 
+
 gulpset.gulp.task(
   'production',
   gulpset.gulp.series(

--- a/gulpset/tasks/deployrsync/index.js
+++ b/gulpset/tasks/deployrsync/index.js
@@ -1,0 +1,24 @@
+const gulpset = require('./../../gulpset');
+
+// @verbose
+gulpset.gulp.task('deployrsync', () => gulpset.tasks.deployrsync());
+
+gulpset.confs.deployrsync = {
+  options: {
+    root: gulpset.paths.dest + '/',
+    hostname: 'foobarhogehoge@54.64.182.67',
+    destination: 'htdocs/',
+    archive: true,
+    verbose: true,
+    progress: true,
+    delete: true
+  }
+};
+
+//----------------------------------------------------------------------------------------------------
+//
+const rsync = require('gulp-rsync');
+
+gulpset.tasks.deployrsync = () => {
+  return gulpset.gulp.src(gulpset.paths.dest + '/**').pipe(rsync(gulpset.confs.deployrsync.options));
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulpset-skeleton",
-  "version": "3.0.0-beta2",
+  "version": "3.0.0",
   "description": "Gulp based project skeleton with modular tasks.",
   "main": "gulpfile.js",
   "author": "FOURDIGIT Inc., Nobuyuki NISHIGAKI",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
   },
   "dependencies": {
     "@fourdigit/sanitize-4d.css": "^7.0.4",
-    "@fourdigit/scss-utilities": "^1.0.0"
+    "@fourdigit/scss-utilities": "^1.0.0",
+    "gulp-rsync": "^0.0.8"
   },
   "directories": {
     "doc": "docs"
@@ -61,7 +62,8 @@
   "scripts": {
     "start": "gulp",
     "build:prod": "gulp production",
-    "eslint:fix": "yarn eslint --fix"
+    "eslint:fix": "yarn eslint --fix",
+    "deployrsync": "gulp deployrsync"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1499,7 +1499,7 @@ beeper@^1.0.0:
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
   integrity sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=
 
-better-assert@~1.0.0:
+better-assert@^1.0.1, better-assert@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/better-assert/-/better-assert-1.0.2.tgz#40866b9e1b9e0b55b481894311e68faffaebc522"
   integrity sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=
@@ -4990,6 +4990,17 @@ gulp-rename@^1.2.0, gulp-rename@^1.4.0:
   resolved "https://registry.yarnpkg.com/gulp-rename/-/gulp-rename-1.4.0.tgz#de1c718e7c4095ae861f7296ef4f3248648240bd"
   integrity sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg==
 
+gulp-rsync@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/gulp-rsync/-/gulp-rsync-0.0.8.tgz#b3e64835cd6059a4eb121ad58ff71746b4d898cc"
+  integrity sha1-s+ZINc1gWaTrEhrVj/cXRrTYmMw=
+  dependencies:
+    better-assert "^1.0.1"
+    gulp-util "^3.0.0"
+    lodash.every "^2.4.1"
+    lodash.isstring "^2.4.1"
+    through2 "^0.6.1"
+
 gulp-sass-glob@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/gulp-sass-glob/-/gulp-sass-glob-1.0.9.tgz#749549a320d1545a9b3258880734828ab2911e28"
@@ -5062,7 +5073,7 @@ gulp-template@^5.0.0:
     safe-buffer "^5.1.1"
     through2 "^2.0.0"
 
-gulp-util@^3.0.1, gulp-util@^3.0.6, gulp-util@^3.0.7, gulp-util@^3.0.8:
+gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.6, gulp-util@^3.0.7, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -6421,6 +6432,21 @@ lodash._arraymap@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._arraymap/-/lodash._arraymap-3.0.0.tgz#1a8fd0f4c0df4b61dea076d717cdc97f0a3c3e66"
   integrity sha1-Go/Q9MDfS2HeoHbXF83Jfwo8PmY=
 
+lodash._arraypool@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._arraypool/-/lodash._arraypool-2.4.1.tgz#e88eecb92e2bb84c9065612fd958a0719cd47f94"
+  integrity sha1-6I7suS4ruEyQZWEv2VigcZzUf5Q=
+
+lodash._basebind@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basebind/-/lodash._basebind-2.4.1.tgz#e940b9ebdd27c327e0a8dab1b55916c5341e9575"
+  integrity sha1-6UC5690nwyfgqNqxtVkWxTQelXU=
+  dependencies:
+    lodash._basecreate "~2.4.1"
+    lodash._setbinddata "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isobject "~2.4.1"
+
 lodash._basecallback@^3.0.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz#b7b2bb43dc2160424a21ccf26c57e443772a8e27"
@@ -6435,6 +6461,35 @@ lodash._basecopy@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz#8da0e6a876cf344c0ad8a54882111dd3c5c7ca36"
   integrity sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=
+
+lodash._basecreate@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-2.4.1.tgz#f8e6f5b578a9e34e541179b56b8eeebf4a287e08"
+  integrity sha1-+Ob1tXip405UEXm1a47uv0oofgg=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash.isobject "~2.4.1"
+    lodash.noop "~2.4.1"
+
+lodash._basecreatecallback@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreatecallback/-/lodash._basecreatecallback-2.4.1.tgz#7d0b267649cb29e7a139d0103b7c11fae84e4851"
+  integrity sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=
+  dependencies:
+    lodash._setbinddata "~2.4.1"
+    lodash.bind "~2.4.1"
+    lodash.identity "~2.4.1"
+    lodash.support "~2.4.1"
+
+lodash._basecreatewrapper@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._basecreatewrapper/-/lodash._basecreatewrapper-2.4.1.tgz#4d31f2e7de7e134fbf2803762b8150b32519666f"
+  integrity sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=
+  dependencies:
+    lodash._basecreate "~2.4.1"
+    lodash._setbinddata "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isobject "~2.4.1"
 
 lodash._baseeach@^3.0.0:
   version "3.0.4"
@@ -6457,6 +6512,17 @@ lodash._baseisequal@^3.0.0:
     lodash.istypedarray "^3.0.0"
     lodash.keys "^3.0.0"
 
+lodash._baseisequal@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._baseisequal/-/lodash._baseisequal-2.4.1.tgz#6b1e62e587c5523111f6f228553dab19e445fc03"
+  integrity sha1-ax5i5YfFUjER9vIoVT2rGeRF/AM=
+  dependencies:
+    lodash._getarray "~2.4.1"
+    lodash._objecttypes "~2.4.1"
+    lodash._releasearray "~2.4.1"
+    lodash.forin "~2.4.1"
+    lodash.isfunction "~2.4.1"
+
 lodash._basetostring@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz#d1861d877f824a52f669832dcaf3ee15566a07d5"
@@ -6472,6 +6538,23 @@ lodash._bindcallback@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
   integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
 
+lodash._createwrapper@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._createwrapper/-/lodash._createwrapper-2.4.1.tgz#51d6957973da4ed556e37290d8c1a18c53de1607"
+  integrity sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=
+  dependencies:
+    lodash._basebind "~2.4.1"
+    lodash._basecreatewrapper "~2.4.1"
+    lodash._slice "~2.4.1"
+    lodash.isfunction "~2.4.1"
+
+lodash._getarray@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._getarray/-/lodash._getarray-2.4.1.tgz#faf1f7f810fa985a251c2187404481094839e5ee"
+  integrity sha1-+vH3+BD6mFolHCGHQESBCUg55e4=
+  dependencies:
+    lodash._arraypool "~2.4.1"
+
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
@@ -6481,6 +6564,21 @@ lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
   integrity sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=
+
+lodash._isnative@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._isnative/-/lodash._isnative-2.4.1.tgz#3ea6404b784a7be836c7b57580e1cdf79b14832c"
+  integrity sha1-PqZAS3hKe+g2x7V1gOHN95sUgyw=
+
+lodash._maxpoolsize@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._maxpoolsize/-/lodash._maxpoolsize-2.4.1.tgz#9d482f463b8e66afbe59c2c14edb117060172334"
+  integrity sha1-nUgvRjuOZq++WcLBTtsRcGAXIzQ=
+
+lodash._objecttypes@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz#7c0b7f69d98a1f76529f890b0cdb1b4dfec11c11"
+  integrity sha1-fAt/admKH3ZSn4kLDNsbTf7BHBE=
 
 lodash._reescape@^3.0.0:
   version "3.0.0"
@@ -6497,10 +6595,38 @@ lodash._reinterpolate@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
   integrity sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=
 
+lodash._releasearray@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._releasearray/-/lodash._releasearray-2.4.1.tgz#a6139630d76d1536b07ddc80962889b082f6a641"
+  integrity sha1-phOWMNdtFTawfdyAliiJsIL2pkE=
+  dependencies:
+    lodash._arraypool "~2.4.1"
+    lodash._maxpoolsize "~2.4.1"
+
 lodash._root@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash._root/-/lodash._root-3.0.1.tgz#fba1c4524c19ee9a5f8136b4609f017cf4ded692"
   integrity sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=
+
+lodash._setbinddata@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._setbinddata/-/lodash._setbinddata-2.4.1.tgz#f7c200cd1b92ef236b399eecf73c648d17aa94d2"
+  integrity sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash.noop "~2.4.1"
+
+lodash._shimkeys@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz#6e9cc9666ff081f0b5a6c978b83e242e6949d203"
+  integrity sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=
+  dependencies:
+    lodash._objecttypes "~2.4.1"
+
+lodash._slice@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash._slice/-/lodash._slice-2.4.1.tgz#745cf41a53597b18f688898544405efa2b06d90f"
+  integrity sha1-dFz0GlNZexj2iImFREBe+isG2Q8=
 
 lodash._topath@^3.0.0:
   version "3.8.1"
@@ -6513,6 +6639,14 @@ lodash.assign@^4.0.3, lodash.assign@^4.0.6, lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
   integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
+
+lodash.bind@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-2.4.1.tgz#5d19fa005c8c4d236faf4742c7b7a1fcabe29267"
+  integrity sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=
+  dependencies:
+    lodash._createwrapper "~2.4.1"
+    lodash._slice "~2.4.1"
 
 lodash.capitalize@^4.1.0:
   version "4.2.1"
@@ -6529,6 +6663,17 @@ lodash.clonedeep@^4.3.2:
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
   integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
+lodash.createcallback@~2.4.1:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/lodash.createcallback/-/lodash.createcallback-2.4.4.tgz#4a4530849b01655003fcbdf563524eff3ceb02c4"
+  integrity sha1-SkUwhJsBZVAD/L31Y1JO/zzrAsQ=
+  dependencies:
+    lodash._basecreatecallback "~2.4.1"
+    lodash._baseisequal "~2.4.1"
+    lodash.isobject "~2.4.1"
+    lodash.keys "~2.4.1"
+    lodash.property "~2.4.1"
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -6540,6 +6685,36 @@ lodash.escape@^3.0.0:
   integrity sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=
   dependencies:
     lodash._root "^3.0.0"
+
+lodash.every@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.every/-/lodash.every-2.4.1.tgz#228ce585e6f490c0329805b8fc0facd415b83b05"
+  integrity sha1-Iozlheb0kMAymAW4/A+s1BW4OwU=
+  dependencies:
+    lodash.createcallback "~2.4.1"
+    lodash.forown "~2.4.1"
+
+lodash.forin@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.forin/-/lodash.forin-2.4.1.tgz#8089eaed7d25b08672b7c66fd07ac55d062320eb"
+  integrity sha1-gInq7X0lsIZyt8Zv0HrFXQYjIOs=
+  dependencies:
+    lodash._basecreatecallback "~2.4.1"
+    lodash._objecttypes "~2.4.1"
+
+lodash.forown@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.forown/-/lodash.forown-2.4.1.tgz#78b41eafe1405fa966459ea4193fd502d084524b"
+  integrity sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=
+  dependencies:
+    lodash._basecreatecallback "~2.4.1"
+    lodash._objecttypes "~2.4.1"
+    lodash.keys "~2.4.1"
+
+lodash.identity@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.identity/-/lodash.identity-2.4.1.tgz#6694cffa65fef931f7c31ce86c74597cf560f4f1"
+  integrity sha1-ZpTP+mX++TH3wxzobHRZfPVg9PE=
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -6561,6 +6736,23 @@ lodash.isfinite@^3.3.2:
   resolved "https://registry.yarnpkg.com/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz#fb89b65a9a80281833f0b7478b3a5104f898ebb3"
   integrity sha1-+4m2WpqAKBgz8LdHizpRBPiY67M=
 
+lodash.isfunction@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-2.4.1.tgz#2cfd575c73e498ab57e319b77fa02adef13a94d1"
+  integrity sha1-LP1XXHPkmKtX4xm3f6Aq3vE6lNE=
+
+lodash.isobject@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-2.4.1.tgz#5a2e47fe69953f1ee631a7eba1fe64d2d06558f5"
+  integrity sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=
+  dependencies:
+    lodash._objecttypes "~2.4.1"
+
+lodash.isstring@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-2.4.1.tgz#3a4a42ee344b5bc09aeaa87ef1dc3097789d0792"
+  integrity sha1-OkpC7jRLW8Ca6qh+8dwwl3idB5I=
+
 lodash.istypedarray@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz#c9a477498607501d8e8494d283b87c39281cef62"
@@ -6580,6 +6772,15 @@ lodash.keys@^3.0.0:
     lodash.isarguments "^3.0.0"
     lodash.isarray "^3.0.0"
 
+lodash.keys@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-2.4.1.tgz#48dea46df8ff7632b10d706b8acb26591e2b3727"
+  integrity sha1-SN6kbfj/djKxDXBrissmWR4rNyc=
+  dependencies:
+    lodash._isnative "~2.4.1"
+    lodash._shimkeys "~2.4.1"
+    lodash.isobject "~2.4.1"
+
 lodash.map@^3.0.0:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-3.1.4.tgz#b483acd1b786c5c7b492c495f7b5266229bc00c2"
@@ -6595,6 +6796,11 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
   integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
+
+lodash.noop@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-2.4.1.tgz#4fb54f816652e5ae10e8f72f717a388c7326538a"
+  integrity sha1-T7VPgWZS5a4Q6PcvcXo4jHMmU4o=
 
 lodash.pairs@^3.0.0:
   version "3.0.1"
@@ -6613,6 +6819,11 @@ lodash.pluck@^3.1.2:
     lodash.isarray "^3.0.0"
     lodash.map "^3.0.0"
 
+lodash.property@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.property/-/lodash.property-2.4.1.tgz#4049c0549daf5a7102bc5e93eeaebb379deb132f"
+  integrity sha1-QEnAVJ2vWnECvF6T7q67N53rEy8=
+
 lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
@@ -6622,6 +6833,13 @@ lodash.some@^4.2.2:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
   integrity sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=
+
+lodash.support@~2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/lodash.support/-/lodash.support-2.4.1.tgz#320e0b67031673c28d7a2bb5d9e0331a45240515"
+  integrity sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=
+  dependencies:
+    lodash._isnative "~2.4.1"
 
 lodash.template@^3.0.0:
   version "3.6.2"


### PR DESCRIPTION
`yarn deployrsync` でテスト環境等へデプロイできるタスクを追加しました。
`develop`ブランチへのプッシュ時にも`bitbucket-pipelines`を使ってデプロイできるようにしています。
方法は`README.md`をご覧ください。

当初`deploy`というタスク名にしていたのですが、将来的にS3へデプロイするタスク等作成の可能性もあるため、`deployrsync`という名前にしています。

`pipeline`上でのビルド高速化及びログの可読性向上のため、`node+rsync`カスタムイメージを作成して使用しています。
https://hub.docker.com/r/fourdigit/node-rsync-tagged/
（ソース管理はGitHub: https://github.com/fourdigit/docker-node-rsync-tagged ）
↑どちらも`fourdigit` organization上で共有してあるので、今後Nodeのバージョンが上がった際等は、適宜更新をしていけたらと思います。