### PR TITLE
ejsUtils.defaultParamsMapperが配列以外受け付けなかったので修正

### DIFF
--- a/src/_head.ejs
+++ b/src/_head.ejs
@@ -4,6 +4,15 @@ include('/_utils');
 // このブロックでは、このコンポーネントのdefault valueを設定します。
 // include('/_head', {title: 'xxxxx'}) のような形でオプションを渡した時には、それが利用され、
 // 渡されていない時には下記のデフォルト値が使われます。
+/*
+例）
+titleに "default title" というデフォルト値が設定されていた場合、
+include('/_head', {title: 'aaa'}) => 'aaa'
+include('/_head', {title: ''}) => ''
+include('/_head', {title: null}) => null
+include('/_head', {}) => 'default title'
+include('/_head', {title: undefined}) => 'default title'
+*/
 
 const params = ejsUtils.defaultParamsMapper(locals, {
   title: '共通タイトル',

--- a/src/_utils.ejs
+++ b/src/_utils.ejs
@@ -10,8 +10,7 @@ ejsUtils = {};
 ejsUtils.defaultParamsMapper = (locals, defaultParams) => {
   const result = {};
   Object.keys(defaultParams).forEach(localKey => {
-    result[localKey] = (locals[localKey] && locals[localKey].length && locals[localKey].length > 0) ? locals[localKey] : defaultParams[localKey]
-  });
+    result[localKey] = typeof locals[localKey] === "undefined" ? defaultParams[localKey] : locals[localKey]  });
   return result;
 }
 

--- a/src/_utils.ejs
+++ b/src/_utils.ejs
@@ -7,6 +7,16 @@ ejsのユーティリティ関数置き場。
 ejsUtils = {};
 
 // partialに渡されたデータと、デフォルトの値を付き合わせて返却。_head.ejsの利用例を参照
+/*
+例）
+titleに "default title" というデフォルト値が設定されていた場合、
+include('/_head', {title: 'aaa'}) => 'aaa'
+include('/_head', {title: ''}) => ''
+include('/_head', {title: null}) => null
+include('/_head', {}) => 'default title'
+include('/_head', {title: undefined}) => 'default title'
+*/
+
 ejsUtils.defaultParamsMapper = (locals, defaultParams) => {
   const result = {};
   Object.keys(defaultParams).forEach(localKey => {


### PR DESCRIPTION
EJSの`include`引数の有無を判断して、デフォルト値へマップする`defaultParamsMapper`が配列以外（プリミティブや`length`属性を持たないオブジェクト）を受け付けていなかったため、ロジックの修正を行いました。

渡された値が`undefined`だった時のみデフォルト値を使い、空文字列や`null`, `NaN`などその他falseyなケースを含め、`undefined`以外の際はパラメーター値をそのまま使うような調整にしています。
‌

以下テストケースです。

```
pram: 100, expected: 100 => OK
pram: -100, expected: -100 => OK
pram: 0, expected: 0 => OK
pram: NaN, expected: NaN => OK
pram: true, expected: true => OK
pram: false, expected: false => OK
pram: 'abcdefg', expected: 'abcdefg' => OK
pram: '', expected: '' => OK
pram: [1,2,3], expected: [1,2,3] => OK
pram: [], expected: [] => OK
pram: {aaa: 'bbb'}, expected: {aaa: 'bbb'} => OK
pram: {}, expected: {} => OK
pram: null, expected: null => OK

pram: undefined, expected: デフォルト値 => OK
```