### PR TITLE
[WIP] Feat/create gulpset skeleton

### DIFF
--- a/gulpset/init.js
+++ b/gulpset/init.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+const cp = require('child_process');
+const path = require('path');
+const colors = require('ansi-colors');
+const fs = require('fs-extra');
+
+const cwd = process.cwd();
+const pkgRootPath = path.resolve(__dirname, '..');
+
+const packageJson = require('../package.json');
+// eslint-disable-next-line no-magic-numbers
+const additionalArgs = require('minimist')(process.argv.slice(2))._;
+
+const handleExit = () => {
+  console.log('Exiting without error.');
+  process.exit();
+};
+
+const handleError = e => {
+  console.error('ERROR! An error was encountered while executing');
+  console.error(e);
+  console.log('Exiting with error.');
+  process.exit(1);
+};
+
+process.on('SIGINT', handleExit);
+process.on('uncaughtException', handleError);
+
+function validateArgs(args) {
+  const prjName = args.length ? args[0] : undefined;
+  if (!prjName) {
+    console.error('Please specify the project name.');
+    process.exit(1);
+  }
+}
+
+/**
+ * Validate app name
+ * Exit with code 1 if name is invalid
+ *
+ * @param {string} name name of the app
+ * @param {Array<string>} dependencies list of dependencies of `create-gulpset-skeleton`
+ */
+function checkAppName(name, dependencies) {
+  // TODO: validate package name base on npm naming rules
+  // https://github.com/npm/cli/blob/latest/doc/files/package.json.md#name
+}
+
+/**
+ * Create new project `name` using `gulpset-skeleton`
+ *
+ * @param {*} name
+ */
+function createApp(name) {
+  const root = path.resolve(name);
+  const appName = path.basename(root);
+
+  checkAppName(appName, [...Object.keys(packageJson.dependencies), ...Object.keys(packageJson.devDependencies)]);
+  if (fs.existsSync(path.join(cwd, name))) {
+    console.error(`ERROR! Directory ${name} already exist. Please remove it before proceeding.`);
+    process.exit(1);
+  }
+  fs.ensureDirSync(name);
+
+  // TODO: use `fs.readdirSync` to list files and directories
+  const filesToCopy = [
+    'README.md',
+    'aigis_config.yml',
+    'gulpfile.js',
+    'package.json',
+    'webpack.config.js',
+    'webpack.config.prod.js'
+  ];
+  const directoriesToCopy = ['gulpset', 'src'];
+
+  for (let i = 0; i < filesToCopy.length; i++) {
+    const srcFilePath = path.join(pkgRootPath, filesToCopy[i]);
+    const dstFilePath = path.join(cwd, name, filesToCopy[i]);
+    fs.copyFileSync(srcFilePath, dstFilePath);
+  }
+
+  for (let i = 0; i < directoriesToCopy.length; i++) {
+    const srcDirPath = path.join(pkgRootPath, directoriesToCopy[i]);
+    const dstDirPath = path.join(cwd, name, directoriesToCopy[i]);
+    fs.copySync(srcDirPath, dstDirPath);
+  }
+
+  // TODO: run `yarn install`
+}
+
+validateArgs(additionalArgs);
+const prjName = additionalArgs[0];
+createApp(prjName);

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
     "eslint:fix": "yarn eslint --fix",
     "deployrsync": "gulp deployrsync"
   },
+  "bin": {
+    "create-gulpset-skeleton": "gulpset/init.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fourdigitdesign/gulpset.git"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "gulpset-skeleton",
+  "name": "create-gulpset-skeleton",
   "version": "3.1.0",
   "description": "Gulp based project skeleton with modular tasks.",
   "main": "gulpfile.js",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
   },
   "dependencies": {
     "@fourdigit/sanitize-4d.css": "^7.0.4",
-    "@fourdigit/scss-utilities": "^1.0.0"
+    "@fourdigit/scss-utilities": "^1.0.0",
+    "cross-spawn": "^6.0.5",
+    "fs-extra": "^7.0.1",
+    "minimist": "^1.2.0"
   },
   "directories": {
     "doc": "docs"


### PR DESCRIPTION
In this PR
- Change the package name from `gulpset-skeleton` to `create-gulpset-skeleton`
- Create initialization script. It will copy skeleton files and directory from the package `create-gulpset-skeleton` into new project.

## To-dos
I see some rooms for improvement:
- Validate project name to follow [npm naming rules](https://github.com/npm/cli/blob/latest/doc/files/package.json.md#name) and avoid conflict with existing packages.
- After copy skeleton files and dirs, `init` script should run `yarn install` to install all the dependencies listed within package.json.
- Colorize console message. Currently log and error message are the same color.
- Isolate init script `init.js`. Currently it's in `gulpset/`. I think it should not be part of the skeleton.
