### PR TITLE
.gitignore修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ docs/jsdoc
 .LSOverride
 
 # Icon must end with two \r
-Icon
+Icon^M^M
 # Thumbnails
 ._*
 # Files that might appear in the root of a volume


### PR DESCRIPTION
`icon`というフォルダ名を使用すると無視されるため`.gitignore`を修正いたしました。
https://huwahuwa.org/post-4266/